### PR TITLE
Darstellen der Antworten in EvaluateSurveysData

### DIFF
--- a/app/Http/Controllers/SurveyController.php
+++ b/app/Http/Controllers/SurveyController.php
@@ -29,11 +29,12 @@ class SurveyController extends Controller
     {
 
         $questionnaire = $survey->questionnaire()->with('questions')->first();
-        $questions = $questionnaire->questions()->with('answers')->get();
+        $questions = $questionnaire->questions()->with('answers')->withCount('answers')->get();
 //        $answers = $questions->answers()->get();
         return view('surveys.evaluate.evaluateSurveyData', ['survey' => $survey,
             'questionnaire' => $questionnaire,
             'questions' => $questions,
+//            'answers' => $answers,
             'user' => Auth::user()]);
     }
 

--- a/app/Http/Controllers/SurveyController.php
+++ b/app/Http/Controllers/SurveyController.php
@@ -42,4 +42,16 @@ class SurveyController extends Controller
         return view('surveys.create.createSurveys', ['classes' => SchoolClass::all(), 'user' => Auth::user()]);
     }
 
+    public static function calculateRatingColor(int $value)
+    {
+        //Übernommen von Juris Code -> Benötigt u.a. für die View evaluateSurveyData
+        if (0 <= $value && $value < 33) {
+            return 'progress-error';
+        } elseif (33 < $value && $value < 66) {
+            return 'progress-warning';
+        } else {
+            return 'progress-success';
+        }
+    }
+
 }

--- a/app/Livewire/TableAnswerCount.php
+++ b/app/Livewire/TableAnswerCount.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class TableAnswerCount extends Component
+{
+    //Anzahl der Antworten auf die Frage
+    public ?int $answers_count = null;
+    //Anzahl der Antworten auf jede Antwortmöglichkeit
+    public $counts;
+    public function render()
+    {
+        return view('livewire.table-answer-count');
+    }
+}

--- a/app/Models/Survey.php
+++ b/app/Models/Survey.php
@@ -15,10 +15,6 @@ class Survey extends Model
         return $this->belongsTo(SchoolClass::class, 'school_class_id');
     }
 
-    public function answers()
-    {
-        return $this->hasMany(SurveyAnswer::class, 'survey_id');
-    }
 
     public function questionnaire() {
         return $this->belongsTo(Questionnaire::class, 'questionnaire_id');

--- a/app/Models/SurveyAnswer.php
+++ b/app/Models/SurveyAnswer.php
@@ -11,6 +11,11 @@ class SurveyAnswer extends Model
 
     public function question()
     {
-        return $this->belongsTo(SurveyQuestion::class);
+        return $this->belongsToMany(SurveyQuestion::class);
+    }
+
+    public function survey()
+    {
+        return $this->belongsToMany(Survey::class);
     }
 }

--- a/app/Models/SurveyQuestion.php
+++ b/app/Models/SurveyQuestion.php
@@ -12,11 +12,16 @@ class SurveyQuestion extends Model
 
     public function answers()
     {
-        return $this->hasMany(SurveyAnswer::class);
+        return $this->hasMany(SurveyAnswer::class, 'survey_question_id');
     }
 
     public function questionnaire(): belongsToMany {
         return $this->belongsToMany(Questionnaire::class);
+    }
+
+    public function survey(): belongsToMany
+    {
+        return $this->belongsToMany(Survey::class);
     }
 
 }

--- a/database/factories/SurveyAnswerFactory.php
+++ b/database/factories/SurveyAnswerFactory.php
@@ -22,7 +22,7 @@ class SurveyAnswerFactory extends Factory
             ->where('surveys.id', '=', $chosen_survey)
             ->pluck('survey_question_id');
         return [
-            'chosen_answer' => $this->faker->numberBetween(1, 5),
+            'chosen_answer' => $this->faker->numberBetween(1, 4),
             'survey_id' => $chosen_survey,
             'survey_question_id' => $this->faker->randomElement($questions_in_survey),
         ];

--- a/resources/views/livewire/table-answer-count.blade.php
+++ b/resources/views/livewire/table-answer-count.blade.php
@@ -1,0 +1,16 @@
+<div>
+    @php
+    $headers = [
+    ['key' => 'chosen_answer', 'label' => 'Gewählte Option'],
+    ['key' => 'answer_count', 'label' => 'Anzahl'],
+    ];
+    @endphp
+
+    <div class="col-span-1 text-pretty">
+        Anzahl der Antworten: {{$answers_count}}
+    </div>
+
+    <div>
+        <x-table :headers="$headers" :rows="$counts" no-hover />
+    </div>
+</div>

--- a/resources/views/surveys/evaluate/evaluateSurveyData.blade.php
+++ b/resources/views/surveys/evaluate/evaluateSurveyData.blade.php
@@ -1,25 +1,38 @@
 @extends('layout')
 
 @section('content')
-    @php
-        $value = rand(1, 100);
-        $color = App\Http\Controllers\SurveyController::calculateRatingColor($value);
-    @endphp
     <!-- der value wert soll aus einer funktion gezogen werden, welche diesen aus den antworten der survey fragen berechnet.-->
     @if ($survey)
     <x-header title=" {{ $survey->surveycode }}"></x-header>
     <!--foreach Fragen ergebnis in wert-->
-        <x-card title="Frage: Nummer(ID)" class="shadow-md">
+    @foreach($questions as $question)
+        <x-card title="Frage: {{$question->question}}" class="shadow-md">
             <div class="flex flex-cols-2 space-y-4 md:flex-row md:items-center md:space-x-6 my-4">
-            <div class="col-span-1 text-pretty">
-                <!--Die Frage.  event. {{-- $survey['frageInhalt'] --}}-->
-                Inhalt der Frage ############## ############ ####### ######## ########## ########### ################ ####### ################
-            </div>
-            <x-progress id="ranking1" value="{{$value}}" max="100" class="h-6 {{$color}}"/>
+{{--                Anzahl Antworten--}}
+
+                @php
+//              Anzahl Antworten für jede Option
+                $counts = $question->answers()
+                  ->groupBy(['chosen_answer'])
+                  ->select('chosen_answer', DB::raw('count(*) as answer_count'))
+                  ->get();
+//              Durchschnittswert der Fragen für die Balkenanzeige
+                $average = $question->answers()
+                  ->select(DB::raw('(avg(chosen_answer)-1) as avg_answer'))
+                  ->first()
+                  ->avg_answer;
+//                Setzen des Balkenwertes und -Farbe
+                $value = round(33.33 * $average, 2);
+                $color = App\Http\Controllers\SurveyController::calculateRatingColor($value);
+                @endphp
+
+                <livewire:table-answer-count :answers_count="$question->answers_count" :counts="$counts"></livewire:table-answer-count>
+            <x-progress id="ranking1" value="{{$value}}" max="100" class="{{$color}} h-6"/>
             <label for="ranking1" class="text-lg font-semibold text-gray-700">{{$value}}%</label>
             </div>
 
         </x-card>
+    @endforeach
     @endif
     <x-button label="Als PDF drucken" class="btn-warning mx-10" icon="o-check" disabled />
 @endsection

--- a/resources/views/surveys/evaluate/evaluateSurveyData.blade.php
+++ b/resources/views/surveys/evaluate/evaluateSurveyData.blade.php
@@ -2,13 +2,12 @@
 
 @section('content')
     @php
-        $survey = App\Models\Survey::Where('id', $_GET['survey'])->get()->toArray();
         $value = rand(1, 100);
-        $colour = calculateBewertungColour($value);
+        $color = App\Http\Controllers\SurveyController::calculateRatingColor($value);
     @endphp
     <!-- der value wert soll aus einer funktion gezogen werden, welche diesen aus den antworten der survey fragen berechnet.-->
     @if ($survey)
-    <x-header title=" {{ $survey['surveycode'] }}"></x-header>
+    <x-header title=" {{ $survey->surveycode }}"></x-header>
     <!--foreach Fragen ergebnis in wert-->
         <x-card title="Frage: Nummer(ID)" class="shadow-md">
             <div class="flex flex-cols-2 space-y-4 md:flex-row md:items-center md:space-x-6 my-4">
@@ -16,7 +15,7 @@
                 <!--Die Frage.  event. {{-- $survey['frageInhalt'] --}}-->
                 Inhalt der Frage ############## ############ ####### ######## ########## ########### ################ ####### ################
             </div>
-            <x-progress id="ranking1" value="{{$value}}" max="100" class="h-6 {{$colour}}"/>
+            <x-progress id="ranking1" value="{{$value}}" max="100" class="h-6 {{$color}}"/>
             <label for="ranking1" class="text-lg font-semibold text-gray-700">{{$value}}%</label>
             </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,7 +37,7 @@ Route::get('/userverwaltung', [UserController::class, 'showUsers'])->middleware(
 
 
 //#################Authentication#################
-Route::get('/Login', Login::class)->name('Login');
+Route::get('/Login', Login::class)->name('login');
 //Route::get('/register', [RegisterController::class, 'create'])->name('register');
 //Route::post('/register', [RegisterController::class, 'store'])->name('register_store');
 Route::get('/Logout', [LogoutController::class, 'logout'])->name('logout');


### PR DESCRIPTION
EvaluateSurveysData hat nun folgende Features:

- Anzahl der Antwortmöglichkeiten werden dargestellt
- Die gewählten Antwortmöglichkeiten und deren Anzahl werden dargestellt
- Der Mittelwert der Antworten wird gebildet und in das Balkendiagramm übertragen (muss noch auf die Anzahl der Antwortmöglichkeiten dynamisch angepasst werden, aktuell wird 4 angenommen)

## NOCH ZU FIXEN!
Aus irgendeinem Grund funktioniert progress-warning und progress-error nicht korrekt. Lediglich das Standard-Display und die progress-success-Klasse funktionierten @DieBratkartoffel @DoescherJonas bitte gegenchecken.